### PR TITLE
add experimental virtual/simulated input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A [Godot](https://godotengine.org/)-inspired action input handling system for [E
 * Bind keys with modifiers to a single action (like `ctrl+c`)
 * Simplified multi-input handling (like multiple gamepads)
 * Simplified keymap loading from a file (see [configfile](_examples/configfile/main.go) example)
+* Implements simulated/virtual input events (see [simulateinput](_examples/simulateinput/main.go) example)
 * No extra dependencies (apart from the [Ebitengine](https://github.com/hajimehoshi/ebiten) of course)
 * Solves some issues related to gamepads in browsers
 * Wheel/scroll as action events

--- a/_examples/simulateinput/main.go
+++ b/_examples/simulateinput/main.go
@@ -1,0 +1,109 @@
+//go:build example
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	input "github.com/quasilyte/ebitengine-input"
+)
+
+const (
+	ActionUnknown input.Action = iota
+	ActionSpace
+	ActionEnter
+	ActionClick
+)
+
+func main() {
+	ebiten.SetWindowSize(640, 480)
+
+	if err := ebiten.RunGame(newExampleGame()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type exampleGame struct {
+	started bool
+
+	frame         int
+	pressingEnter bool
+
+	inputHandler *input.Handler
+	inputSystem  input.System
+}
+
+func newExampleGame() *exampleGame {
+	g := &exampleGame{}
+
+	g.inputSystem.Init(input.SystemConfig{
+		DevicesEnabled: input.AnyDevice,
+	})
+
+	return g
+}
+
+func (g *exampleGame) Layout(outsideWidth, outsideHeight int) (int, int) {
+	return 640, 480
+}
+
+func (g *exampleGame) Draw(screen *ebiten.Image) {
+	ebitenutil.DebugPrint(screen, "check out the stdout logs\ntry clicking, pressing space/enter")
+}
+
+func (g *exampleGame) Update() error {
+	g.inputSystem.Update()
+
+	if !g.started {
+		g.Init()
+		g.started = true
+	}
+
+	g.frame++
+	// Every 90 frames, emit some events and toggle the enter pressing mode.
+	// Note: the simulated input events won't be detected until the next frame.
+	if g.frame%90 == 0 {
+		g.inputHandler.EmitEvent(input.SimulatedEvent{
+			Key: input.KeySpace,
+		})
+		g.inputHandler.EmitEvent(input.SimulatedEvent{
+			Key: input.KeyMouseLeft,
+			Pos: input.Vec{X: 100, Y: 100},
+		})
+		g.pressingEnter = !g.pressingEnter
+		fmt.Printf(">> frame %d: switch 'pressing enter' (now %v)\n", g.frame, g.pressingEnter)
+		fmt.Printf(">> frame %d: simulate space key press\n", g.frame)
+		fmt.Printf(">> frame %d: simulate a mouse click at (100,100)\n", g.frame)
+	}
+	if g.pressingEnter {
+		g.inputHandler.EmitEvent(input.SimulatedEvent{
+			Key: input.KeyEnter,
+		})
+	}
+
+	if info, ok := g.inputHandler.JustPressedActionInfo(ActionClick); ok {
+		fmt.Printf("<< frame %d: click action is pressed (pos: %f,%f)\n", g.frame, info.Pos.X, info.Pos.Y)
+	}
+	if g.inputHandler.ActionIsPressed(ActionSpace) {
+		fmt.Printf("<< frame %d: space action is pressed\n", g.frame)
+	}
+	if g.inputHandler.ActionIsJustPressed(ActionEnter) {
+		fmt.Printf("<< frame %d: enter action is just pressed\n", g.frame)
+	}
+
+	return nil
+}
+
+func (g *exampleGame) Init() {
+	keymap := input.Keymap{
+		ActionClick: {input.KeyMouseLeft},
+		ActionSpace: {input.KeySpace},
+		ActionEnter: {input.KeyEnter},
+	}
+
+	g.pressingEnter = true
+	g.inputHandler = g.inputSystem.NewHandler(0, keymap)
+}

--- a/event.go
+++ b/event.go
@@ -1,0 +1,49 @@
+package input
+
+// SimulatedEvent represents a virtual input that can be send down the stream.
+//
+// The data carried by this event will be used to construct an EventInfo object.
+//
+// Experimental: this is a part of virtual input API, which is not stable yet.
+type SimulatedEvent struct {
+	Key Key
+
+	Pos Vec
+}
+
+// EventInfo holds extra information about the input device event.
+//
+// Pos carries the event location, if available.
+// Pos is a click location for mouse events.
+// Pos is a tap location for screen touch events.
+// Use HasPos() predicate to know whether there is a pos associated
+// with the event to distinguish between (0, 0) pos and lack of pos info.
+type EventInfo struct {
+	kind   keyKind
+	hasPos bool
+
+	Pos Vec
+}
+
+// HasPos reports whether this event has a position associated with it.
+// Use Pos field to get the pos value.
+func (e EventInfo) HasPos() bool { return e.hasPos }
+
+// IsTouchEvent reports whether this event was triggered by a screen touch device.
+func (e EventInfo) IsTouchEvent() bool { return e.kind == keyTouch }
+
+// IsKeyboardEvent reports whether this event was triggered by a keyboard device.
+func (e EventInfo) IsKeyboardEvent() bool { return e.kind == keyKeyboard }
+
+// IsMouseEvent reports whether this event was triggered by a mouse device.
+func (e EventInfo) IsMouseEvent() bool { return e.kind == keyMouse }
+
+// IsGamepadEvent reports whether this event was triggered by a gamepad device.
+func (e EventInfo) IsGamepadEvent() bool {
+	switch e.kind {
+	case keyGamepad, keyGamepadLeftStick, keyGamepadRightStick:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal_bool3.go
+++ b/internal_bool3.go
@@ -1,0 +1,9 @@
+package input
+
+type bool3 uint8
+
+const (
+	bool3unset bool3 = iota
+	bool3false
+	bool3true
+)

--- a/system.go
+++ b/system.go
@@ -25,6 +25,10 @@ type System struct {
 	gamepadIDs  []ebiten.GamepadID
 	gamepadInfo []gamepadInfo
 
+	pendingEvents       []SimulatedEvent
+	prevSimulatedEvents []SimulatedEvent
+	simulatedEvents     []SimulatedEvent
+
 	touchEnabled bool
 	touchIDs     []ebiten.TouchID
 	touchTapID   ebiten.TouchID
@@ -57,6 +61,16 @@ func (sys *System) Init(config SystemConfig) {
 }
 
 func (sys *System) Update() {
+	// Rotate the events slices.
+	// Pending events become simulated in this frame.
+	// Re-use the other slice capacity to push new events.
+	//	prev simulated <- simulated
+	//	pending <- prev simulated
+	//	simulated <- pending
+	sys.prevSimulatedEvents, sys.pendingEvents, sys.simulatedEvents =
+		sys.simulatedEvents, sys.prevSimulatedEvents, sys.pendingEvents
+	sys.pendingEvents = sys.pendingEvents[:0]
+
 	sys.gamepadIDs = ebiten.AppendGamepadIDs(sys.gamepadIDs[:0])
 	if len(sys.gamepadIDs) != 0 {
 		for i, id := range sys.gamepadIDs {


### PR DESCRIPTION
* A new `SimulatedEvent` type allows to describe a `Key` event
* A new `Handler.EmitEvent` method sends simulated event to the system

If event is emitted on every frame, `ActionIsPressed` will always be true, while `ActionIsJustPressed` will trigger only for the first frame.

The current implementation tries to make virtual input/events almost identical to the physical inputs. So, if key is "pressed" by the virtual input, it can't be released or pressed again by the physical input. In practice, it also means that if `ActionIsJustPressed` reports `true` for the virtual input, it will not report `true` for the physical input unless the virtual events stopped and the key is considered to be in unpressed state.

This is an experimental API.
I haven't tested it in any of my games.

Refs #3