### PR TITLE
allow keys like KeyGamepadLStickUp to overlap

### DIFF
--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -30,7 +30,9 @@ const (
 	ActionUnknown input.Action = iota
 	ActionDebug
 	ActionMoveLeft
+	ActionMoveUp
 	ActionMoveRight
+	ActionMoveDown
 	ActionExit
 	ActionTeleport
 )
@@ -106,7 +108,9 @@ func (g *exampleGame) Init() {
 		// Every action can have a list of keys that can activate it.
 		// KeyGamepadLStick<Direction> implements a D-pad like events for L/R sticks.
 		ActionMoveLeft:  {input.KeyGamepadLeft, input.KeyGamepadLStickLeft, input.KeyLeft, input.KeyA},
+		ActionMoveUp:    {input.KeyGamepadUp, input.KeyGamepadLStickUp, input.KeyUp, input.KeyW},
 		ActionMoveRight: {input.KeyGamepadRight, input.KeyGamepadLStickRight, input.KeyRight, input.KeyD},
+		ActionMoveDown:  {input.KeyGamepadDown, input.KeyGamepadLStickDown, input.KeyDown, input.KeyS},
 		ActionExit: {
 			input.KeyGamepadStart,
 			input.KeyEscape,
@@ -177,8 +181,14 @@ func (p *player) Update() {
 	if p.input.ActionIsPressed(ActionMoveLeft) {
 		p.pos.X -= 4
 	}
+	if p.input.ActionIsPressed(ActionMoveUp) {
+		p.pos.Y -= 4
+	}
 	if p.input.ActionIsPressed(ActionMoveRight) {
 		p.pos.X += 4
+	}
+	if p.input.ActionIsPressed(ActionMoveDown) {
+		p.pos.Y += 4
 	}
 	if info, ok := p.input.JustPressedActionInfo(ActionTeleport); ok {
 		p.pos.X = int(info.Pos.X)

--- a/handler.go
+++ b/handler.go
@@ -470,19 +470,22 @@ func (h *Handler) gamepadStickIsActive(code stickCode, vec Vec) bool {
 	if vecLen(vec) < 0.5 {
 		return false
 	}
+	// Allow some axis overlap to emulate double direction pressing,
+	// like with D-pad buttons.
+	const overlap float64 = math.Pi / 7
 	switch code {
 	case stickUp:
 		angle := angleNormalized(vecAngle(vec))
-		return angle > (math.Pi+math.Pi/4) && angle <= (2*math.Pi-math.Pi/4)
+		return angle > (math.Pi+math.Pi/4)-overlap && angle <= (2*math.Pi-math.Pi/4)+overlap
 	case stickRight:
 		angle := angleNormalized(vecAngle(vec))
-		return angle <= (math.Pi/4) || angle > (2*math.Pi-math.Pi/4)
+		return angle <= (math.Pi/4)+overlap || angle > (2*math.Pi-math.Pi/4)-overlap
 	case stickDown:
 		angle := angleNormalized(vecAngle(vec))
-		return angle > (math.Pi/4) && angle <= (math.Pi-math.Pi/4)
+		return angle > (math.Pi/4)-overlap && angle <= (math.Pi-math.Pi/4)+overlap
 	case stickLeft:
 		angle := angleNormalized(vecAngle(vec))
-		return angle > (math.Pi-math.Pi/4) && angle <= (math.Pi+math.Pi/4)
+		return angle > (math.Pi-math.Pi/4)-overlap && angle <= (math.Pi+math.Pi/4)+overlap
 	}
 	return false
 }


### PR DESCRIPTION
When D-pad emulating stick enters a diagonal zone, both directions will be implied as activated due to the overlapping areas.

This makes it possible to fully emulate the D-pad controls using the stick. For instance, the player can press both left and up D-pad buttons and get the diagonal movement work. It was not possible to achieve that with a stick before.