### PR TITLE
Add press duration to PressedActionInfo

### DIFF
--- a/event.go
+++ b/event.go
@@ -42,10 +42,16 @@ type SimulatedAction struct {
 //
 // StartPos is only set for a few events where it makes sense.
 // A drag event, for instance, will store the "dragging from" location there.
+//
+// Duration carries the key press duration if available.
+// Use HasDuration() predicate to know whether there is a duration associated
+// with the event to distinguish between 0 duration and lack of duration info.
 type EventInfo struct {
-	kind   keyKind
-	hasPos bool
+	kind        keyKind
+	hasPos      bool
+	hasDuration bool
 
+	Duration int
 	Pos      Vec
 	StartPos Vec
 }
@@ -53,6 +59,10 @@ type EventInfo struct {
 // HasPos reports whether this event has a position associated with it.
 // Use Pos field to get the pos value.
 func (e EventInfo) HasPos() bool { return e.hasPos }
+
+// HasDuration reports whether this event has a press duration associated with it.
+// Use Duration field to get the press duration value.
+func (e EventInfo) HasDuration() bool { return e.hasDuration }
 
 // IsTouchEvent reports whether this event was triggered by a screen touch device.
 func (e EventInfo) IsTouchEvent() bool { return e.kind == keyTouch }

--- a/event.go
+++ b/event.go
@@ -44,6 +44,8 @@ type SimulatedAction struct {
 // A drag event, for instance, will store the "dragging from" location there.
 //
 // Duration carries the key press duration if available.
+// Duration specifies how long the key has been pressed in ticks same as inpututil.KeyPressDuration.
+// Duration for  key press with modifiers it will return the lowest duration of all key presses.
 // Use HasDuration() predicate to know whether there is a duration associated
 // with the event to distinguish between 0 duration and lack of duration info.
 type EventInfo struct {

--- a/go.mod
+++ b/go.mod
@@ -5,15 +5,15 @@ go 1.18
 require (
 	github.com/hajimehoshi/ebiten/v2 v2.5.9
 	github.com/quasilyte/gmath v0.0.0-20221217210116-fba37a2e15c7
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 )
 
 require (
 	github.com/ebitengine/purego v0.4.0 // indirect
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b // indirect
 	github.com/jezek/xgb v1.1.0 // indirect
-	golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56 // indirect
 	golang.org/x/image v0.10.0 // indirect
 	golang.org/x/mobile v0.0.0-20230301163155-e0f57694e12c // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56 h1:estk1glOnSVeJ9tdEZZc5mAMDZk5lNJNyJ6DvrBkTEU=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.10.0 h1:gXjUUtwtx5yOE0VKWq1CH4IJAClq4UGgUA3i+rpON9M=
 golang.org/x/image v0.10.0/go.mod h1:jtrku+n79PfroUbvDdeUWMAI+heR786BofxrbiSF+J0=
@@ -43,6 +45,7 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/handler.go
+++ b/handler.go
@@ -239,6 +239,8 @@ func (h *Handler) PressedActionInfo(action Action) (EventInfo, bool) {
 		info.hasPos = keyHasPos(k.kind)
 		info.Pos = h.getKeyPos(k)
 		info.StartPos = h.getKeyStartPos(k)
+		info.hasDuration = keyHasDuration(k.kind)
+		info.Duration = h.getKeyPressDuration(k)
 		return info, true
 	}
 	return EventInfo{}, false
@@ -378,6 +380,25 @@ func (h *Handler) getKeyPos(k Key) Vec {
 		result = h.getStickVec(axis1, axis2)
 	}
 	return result
+}
+
+func (h *Handler) getKeyPressDuration(k Key) int {
+	switch k.kind {
+	case keyKeyboardWithShift:
+		return minOf(inpututil.KeyPressDuration(ebiten.Key(k.code)), inpututil.KeyPressDuration(ebiten.KeyShift))
+	case keyKeyboardWithCtrl:
+		return minOf(inpututil.KeyPressDuration(ebiten.Key(k.code)), inpututil.KeyPressDuration(ebiten.KeyControl))
+	case keyKeyboardWithCtrlShift:
+		return minOf(
+			inpututil.KeyPressDuration(ebiten.Key(k.code)),
+			minOf(
+				inpututil.KeyPressDuration(ebiten.KeyShift),
+				inpututil.KeyPressDuration(ebiten.KeyControl)))
+	case keyKeyboard:
+		return inpututil.KeyPressDuration(ebiten.Key(k.code))
+	}
+
+	return 0
 }
 
 func (h *Handler) keyIsPressed(k Key) bool {

--- a/handler.go
+++ b/handler.go
@@ -382,6 +382,8 @@ func (h *Handler) getKeyPos(k Key) Vec {
 	return result
 }
 
+// getKeyPressDuration returns how long the key has been pressed in ticks same as inpututil.KeyPressDuration.
+// When looking at a key press with modifiers it will return the lowest duration of all key presses.
 func (h *Handler) getKeyPressDuration(k Key) int {
 	switch k.kind {
 	case keyKeyboardWithShift:

--- a/internal_key.go
+++ b/internal_key.go
@@ -54,19 +54,21 @@ type keyKindFlag uint8
 const (
 	keyFlagHasPos keyKindFlag = 1 << iota
 	keyFlagNeedID
+	keyFlagHasDuration
 )
 
-func keyHasPos(k keyKind) bool { return keyKindFlagTable[k]&keyFlagHasPos != 0 }
-func keyNeedID(k keyKind) bool { return keyKindFlagTable[k]&keyFlagNeedID != 0 }
+func keyHasPos(k keyKind) bool      { return keyKindFlagTable[k]&keyFlagHasPos != 0 }
+func keyNeedID(k keyKind) bool      { return keyKindFlagTable[k]&keyFlagNeedID != 0 }
+func keyHasDuration(k keyKind) bool { return keyKindFlagTable[k]&keyFlagHasDuration != 0 }
 
 // Using a 256-byte LUT to get a fast map-like lookup without a bound check.
 var keyKindFlagTable = [256]keyKindFlag{
 	keySimulated: keyFlagHasPos | keyFlagNeedID,
 
-	keyKeyboard:              0,
-	keyKeyboardWithCtrl:      0,
-	keyKeyboardWithShift:     0,
-	keyKeyboardWithCtrlShift: 0,
+	keyKeyboard:              keyFlagHasDuration,
+	keyKeyboardWithCtrl:      keyFlagHasDuration,
+	keyKeyboardWithShift:     keyFlagHasDuration,
+	keyKeyboardWithCtrlShift: keyFlagHasDuration,
 
 	keyGamepad:           keyFlagNeedID,
 	keyGamepadLeftStick:  keyFlagNeedID,

--- a/internal_min.go
+++ b/internal_min.go
@@ -1,0 +1,11 @@
+package input
+
+import "golang.org/x/exp/constraints"
+
+// minOf is a placeholder implementation until Go 1.21's builtin min implementation is available
+func minOf[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Add key press duration to the `PressedActionInfo`'s EventInfo.
Resolves quasilyte/ebitengine-input#32

I've included an internal `minOf` implementation. This can be removed if the required go version can be bumped to 1.21.0+ which has a built-in `min` function with variadic parameter support.
