### PR TITLE
implement ActionIsJustReleased method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,5 @@ lint:
 	$(GOPATH_DIR)/bin/golangci-lint run --build-tags example ./_examples/modkeys
 	$(GOPATH_DIR)/bin/golangci-lint run --build-tags example ./_examples/scroll
 	$(GOPATH_DIR)/bin/golangci-lint run --build-tags example ./_examples/simulateinput
+	$(GOPATH_DIR)/bin/golangci-lint run --build-tags example ./_examples/action_released
 	@echo "everything is OK"

--- a/_examples/action_released/main.go
+++ b/_examples/action_released/main.go
@@ -1,0 +1,109 @@
+//go:build example
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	input "github.com/quasilyte/ebitengine-input"
+)
+
+const (
+	ActionUnknown input.Action = iota
+	ActionAdd
+	ActionSub
+)
+
+func main() {
+	ebiten.SetWindowSize(640, 480)
+
+	if err := ebiten.RunGame(newExampleGame()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type exampleGame struct {
+	started bool
+
+	score int
+
+	inputHandler *input.Handler
+	inputSystem  input.System
+}
+
+func newExampleGame() *exampleGame {
+	g := &exampleGame{}
+
+	g.inputSystem.Init(input.SystemConfig{
+		DevicesEnabled: input.AnyDevice,
+	})
+
+	return g
+}
+
+func (g *exampleGame) Layout(outsideWidth, outsideHeight int) (int, int) {
+	return 640, 480
+}
+
+func (g *exampleGame) Draw(screen *ebiten.Image) {
+	ebitenutil.DebugPrint(screen, strings.Join([]string{
+		"mouse controls:",
+		"  released [left mouse button]: increase score",
+		"  released [ctrl]+[left mouse button]: decrease score",
+		"keyboard controls:",
+		"  released [enter]: increase score",
+		"  released [ctrl]+[enter]: decrease score",
+		"gamepad controls:",
+		"  released [R1]: increase score",
+		"  released [L1]: increase score",
+		"",
+		fmt.Sprintf("score: %d", g.score),
+	}, "\n"))
+}
+
+func (g *exampleGame) Update() error {
+	g.inputSystem.Update()
+
+	if !g.started {
+		g.Init()
+		g.started = true
+	}
+
+	g.handleInput()
+
+	return nil
+}
+
+func (g *exampleGame) handleInput() {
+	// Due to the fact that ActionAdd requires just an LMB while
+	// ActionSub is ctrl+LMB, the ActionAdd can be confused with
+	// ActionSub if it's checked first.
+	// This is due to the fact that ebitengine-input does no
+	// conflict resolution of any kind.
+	// It may start preferring the "longest" key combination
+	// in the future, but for now, you might want to order
+	// the key checks carefully if your keymap might have these conflicts.
+	// See #36 for more details.
+	if g.inputHandler.ActionIsJustReleased(ActionSub) {
+		g.score--
+	} else if g.inputHandler.ActionIsJustReleased(ActionAdd) {
+		g.score++
+	}
+}
+
+func (g *exampleGame) Init() {
+	keymap := input.Keymap{
+		ActionAdd: {input.KeyMouseLeft, input.KeyEnter, input.KeyGamepadR1},
+		ActionSub: {
+			input.KeyWithModifier(input.KeyMouseLeft, input.ModControl),
+			input.KeyWithModifier(input.KeyEnter, input.ModControl),
+			input.KeyGamepadL1,
+		},
+	}
+
+	g.inputHandler = g.inputSystem.NewHandler(0, keymap)
+}


### PR DESCRIPTION
This is not the final implementation as it doesn't handle some tricky combinations like joystick movements that emulate a D-pad.

It also ignores the taps as they're activated at the moment the gesture is finished (i.e. the finger is detached from a screen).

Right now we can handle gamepad, keyboard and mouse key release events.

Key modifiers work too and it's not necessary to release the modifier keys during the same frame as the main key.
So, a `ctrl+lmb` released event would trigger if `lmb` is released while `ctrl` is still being pressed.

A new example demonstrates how to use this new feature. It also demonstrates how to avoid some of the conflicts described in #36 (this is not a novel issue and it's not related to the release events directly).

Refs #25