### PR TITLE
refactor DeviceKind getters in EventInfo, add last device tracking to Handler

### DIFF
--- a/event.go
+++ b/event.go
@@ -67,22 +67,36 @@ func (e EventInfo) HasPos() bool { return e.hasPos }
 func (e EventInfo) HasDuration() bool { return e.hasDuration }
 
 // IsTouchEvent reports whether this event was triggered by a screen touch device.
-func (e EventInfo) IsTouchEvent() bool { return e.kind == keyTouch }
+//
+// Deprecated: Use Source().IsTouch() instead.
+func (e EventInfo) IsTouchEvent() bool {
+	return e.kind.device()&TouchDevice == 0
+}
 
 // IsKeyboardEvent reports whether this event was triggered by a keyboard device.
-func (e EventInfo) IsKeyboardEvent() bool { return e.kind == keyKeyboard }
+//
+// Deprecated: Use Source().IsKeyboard() instead.
+func (e EventInfo) IsKeyboardEvent() bool {
+	return e.kind.device()&KeyboardDevice == 0
+}
 
 // IsMouseEvent reports whether this event was triggered by a mouse device.
-func (e EventInfo) IsMouseEvent() bool { return e.kind == keyMouse }
+//
+// Deprecated: Use Source().IsMouse() instead.
+func (e EventInfo) IsMouseEvent() bool {
+	return e.kind.device()&MouseDevice == 0
+}
 
 // IsGamepadEvent reports whether this event was triggered by a gamepad device.
+//
+// Deprecated: Use Source().IsGamepad() instead.
 func (e EventInfo) IsGamepadEvent() bool {
-	switch e.kind {
-	case keyGamepad, keyGamepadLeftStick, keyGamepadRightStick:
-		return true
-	default:
-		return false
-	}
+	return e.kind.device()&GamepadDevice == 0
+}
+
+// Source returns the set of devices that were used to trigger the event.
+func (e EventInfo) Source() DeviceKind {
+	return e.kind.device()
 }
 
 type simulatedEvent struct {

--- a/input.go
+++ b/input.go
@@ -72,6 +72,26 @@ const (
 	TouchDevice
 )
 
+// IsTouch reports whether this set of devices has touch device.
+func (d DeviceKind) IsTouch() bool {
+	return d&TouchDevice == 0
+}
+
+// IsKeyboard reports whether this set of devices has keyboard device.
+func (d DeviceKind) IsKeyboard() bool {
+	return d&KeyboardDevice == 0
+}
+
+// IsMouse reports whether this set of devices has mouse device.
+func (d DeviceKind) IsMouse() bool {
+	return d&MouseDevice == 0
+}
+
+// IsGamepad reports whether this set of devices has gamepad device.
+func (d DeviceKind) IsGamepad() bool {
+	return d&GamepadDevice == 0
+}
+
 // String returns a pretty-printed representation of the input device mask.
 func (d DeviceKind) String() string {
 	if d == 0 {

--- a/internal_key.go
+++ b/internal_key.go
@@ -25,6 +25,25 @@ const (
 	keySimulated
 )
 
+func (k keyKind) device() DeviceKind {
+	switch k {
+	case keyKeyboard, keyKeyboardWithCtrl, keyKeyboardWithShift, keyKeyboardWithCtrlShift:
+		return KeyboardDevice
+	case keyGamepad, keyGamepadLeftStick, keyGamepadRightStick, keyGamepadStickMotion:
+		return GamepadDevice
+	case keyMouse, keyMouseDrag:
+		return MouseDevice
+	case keyWheel, keyWheelWithCtrl, keyWheelWithShift, keyWheelWithCtrlShift:
+		return MouseDevice
+	case keyMouseWithCtrl, keyMouseWithShift, keyMouseWithCtrlShift:
+		return MouseDevice | KeyboardDevice
+	case keyTouch, keyTouchDrag:
+		return TouchDevice
+	default:
+		return KeyboardDevice
+	}
+}
+
 type touchCode int
 
 const (


### PR DESCRIPTION
It would be useful to get the last used device to change button prompts when the player changes it. In connection with these changes, I moved the device definition getters closer to the type of these same devices in order to use them equally from the event and from the handler. Despite the fact that the previous getters were marked as deprecated, the missing types of pressed keys were added to them.